### PR TITLE
Changes to make it work

### DIFF
--- a/FMXmods/FMX.InAppPurchase.iOS.patch
+++ b/FMXmods/FMX.InAppPurchase.iOS.patch
@@ -1,0 +1,29 @@
+Index: FMX.InAppPurchase.iOS.pas
+===================================================================
+--- FMX.InAppPurchase.iOS.pas	(revision 9096)
++++ FMX.InAppPurchase.iOS.pas	(revision 9097)
+@@ -79,6 +79,7 @@
+   ProductID: string;
+   Price: Double;
+   NumFormatter: NSNumberFormatter;
++  CurrencyCode: string;
+   LocalizedPrice: string;
+   LocalizedTitle: string;
+   LocalizedDescription: string;
+@@ -94,6 +95,7 @@
+   NumFormatter.setNumberStyle(NSNumberFormatterCurrencyStyle);
+   NumFormatter.setLocale(Product.priceLocale);
+   LocalizedPrice := NSStrToStr(NumFormatter.stringFromNumber(Product.Price));
++  CurrencyCode := NSStrToStr(NumFormatter.currencyCode);
+                                              
+   NumFormatter.release;
+   LocalizedTitle := NSStrToStr(Product.LocalizedTitle);
+@@ -104,7 +106,7 @@
+   for I := 0 to Pred(Length(DownloadContentLengths)) do
+     DownloadContentLengths[I] := TNSNumber.Wrap(Product.DownloadContentLengths.objectAtIndex(I)).longLongValue;
+   DownloadContentVersion := NSStrToStr(Product.DownloadContentVersion);
+-  Result := TProduct.Create(ProductID, Price, LocalizedPrice, LocalizedTitle, LocalizedDescription, Downloadable,
++  Result := TProduct.Create(ProductID, Price, CurrencyCode, LocalizedPrice, LocalizedTitle, LocalizedDescription, Downloadable,
+     DownloadContentLengths, DownloadContentVersion);
+ end;
+ 

--- a/FMXmods/FMX.InAppPurchase.patch
+++ b/FMXmods/FMX.InAppPurchase.patch
@@ -1,0 +1,44 @@
+Index: FMX.InAppPurchase.pas
+===================================================================
+--- FMX.InAppPurchase.pas	(revision 9096)
++++ FMX.InAppPurchase.pas	(revision 9097)
+@@ -38,6 +38,7 @@
+   private
+     FProductID: string;
+     FPrice: Double;
++    FCurrencyCode: string;
+     FLocalizedPrice: string;
+     FLocalizedTitle: string;
+     FLocalizedDescription: string;
+@@ -48,12 +49,13 @@
+     // Android supplies just a localized price string, not an actual value
+     // so on Android the Price property will have this constant as a value
+     const PriceNotAvailable = -1;
+-    constructor Create(const ProductID: string; Price: Double;
++    constructor Create(const ProductID: string; Price: Double; CurrencyCode: string;
+       const LocalizedPrice, LocalizedTitle, LocalizedDescription: string;
+       Downloadable: Boolean; const DownloadContentLengths: TDownloadLengths;
+       DownloadContentVersion: string);
+     property ProductID: string read FProductID;
+     property Price: Double read FPrice;
++    property CurrencyCode: string read FCurrencyCode;
+     property LocalizedPrice: string read FLocalizedPrice;
+     property LocalizedTitle: string read FLocalizedTitle;
+     property LocalizedDescription: string read FLocalizedDescription;
+@@ -1036,7 +1038,7 @@
+ 
+ { TProduct }
+ 
+-constructor TProduct.Create(const ProductID: string; Price: Double;
++constructor TProduct.Create(const ProductID: string; Price: Double; CurrencyCode: string;
+   const LocalizedPrice, LocalizedTitle, LocalizedDescription: string; Downloadable: Boolean;
+   const DownloadContentLengths: TDownloadLengths; DownloadContentVersion: string);
+ begin
+@@ -1043,6 +1045,7 @@
+   inherited Create;
+   FProductID := ProductID;
+   FPrice := Price;
++  FCurrencyCode := CurrencyCode;
+   FLocalizedPrice := LocalizedPrice;
+   FLocalizedTitle := LocalizedTitle;
+   FLocalizedDescription := LocalizedDescription;

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Headers translated to Object Pascal using SdkTransform in Delphi Berlin.
 
-Untested.
+Tested to work on Delphi Berlin + XCode 7.3.1 + iOS 9.3.5
 
 Download the AdWords Conversion Tracking SDK:
 https://developers.google.com/app-conversion-tracking/ios/
 
-Deploy the *.a file with your project.
+Save the *.a file in your project search path. It will be automatically linked into your binary.

--- a/iOSapi.GoogleConversionTracking.pas
+++ b/iOSapi.GoogleConversionTracking.pas
@@ -245,23 +245,6 @@ function FakeLoader: DCTConversionReporter; cdecl; external libGoogleConversionT
 implementation
 
 
-{$IFDEF CPUARM}
-initialization
-  {$UNDEF OptiIsOn}
-  {$IFOPT O+} //if optimization is on
-    {$DEFINE OptiIsOn} //remember it was on
-    {$O-} //turn optimization off
-  {$ENDIF}
-
-//    if False then
-//      FakeLoader;
-  {$IFDEF OptiIsOn}
-    {$O+}
-    {$UNDEF OptiIsOn}
-  {$ENDIF}
-{$ENDIF}
-
-
 {$IF defined(IOS) and NOT defined(CPUARM)}
 
 uses

--- a/iOSapi.GoogleConversionTracking.pas
+++ b/iOSapi.GoogleConversionTracking.pas
@@ -19,11 +19,10 @@ uses
   Macapi.CoreFoundation,
   Macapi.CoreServices,
   Macapi.Dispatch,
-  Macapi.Foundation,
+  //Macapi.Foundation,  <- needed to use reportUniversalLinkWithUserActivity
   Macapi.Mach,
   Macapi.ObjCRuntime,
   Macapi.ObjectiveC,
-  Macapi.QuartzCore,
   iOSapi.CocoaTypes,
   iOSapi.Foundation;
 
@@ -82,8 +81,7 @@ type
     [MethodName('reportWithProductID:value:isRepeatable:')]
     { class } procedure reportWithProductIDValueIsRepeatable
       (productID: NSString; value: NSString; isRepeatable: Boolean); cdecl;
-    { class } procedure reportUniversalLinkWithUserActivity
-      (userActivity: NSUserActivity); cdecl;
+//    { class } procedure reportUniversalLinkWithUserActivity (userActivity: NSUserActivity); cdecl;
     { class } function registerReferrer(clickURL: NSURL): Boolean; cdecl;
   end;
 
@@ -240,7 +238,29 @@ const
   libGoogleConversionTracking =
     'libGoogleConversionTracking.a';
 
+//This function is never called (it does not even exist in the library), but it is here to trick Delphi to think that we use the
+//static library and therefore link it into the binary.
+function FakeLoader: DCTConversionReporter; cdecl; external libGoogleConversionTracking name 'OBJC_CLASS_$_SomeClassName';
+
 implementation
+
+
+{$IFDEF CPUARM}
+initialization
+  {$UNDEF OptiIsOn}
+  {$IFOPT O+} //if optimization is on
+    {$DEFINE OptiIsOn} //remember it was on
+    {$O-} //turn optimization off
+  {$ENDIF}
+
+//    if False then
+//      FakeLoader;
+  {$IFDEF OptiIsOn}
+    {$O+}
+    {$UNDEF OptiIsOn}
+  {$ENDIF}
+{$ENDIF}
+
 
 {$IF defined(IOS) and NOT defined(CPUARM)}
 
@@ -249,9 +269,6 @@ uses
 
 var
   GoogleConversionTrackingModule: THandle;
-
-{$ENDIF IOS}
-{$IF defined(IOS) and NOT defined(CPUARM)}
 
 initialization
 

--- a/uGoogleConversionTracking.pas
+++ b/uGoogleConversionTracking.pas
@@ -1,0 +1,50 @@
+unit uGoogleConversionTracking;
+
+interface
+
+uses
+  iOSapi.GoogleConversionTracking, Macapi.Helpers;
+
+const
+  cConversionIDStr = '1071403861';
+  cConversionLabelRun = 'gAhuCK6Ow2kQ1abx_gM';
+  cConversionLabelPurchase = 'a3SOCKDN42kQ1abx_gM';
+
+type
+  tGoogleConversionTracking = class
+    class procedure SetAutomatedReportingEnabled(aEnabled: Boolean);
+    class procedure TrackLaunch;
+    class procedure TrackPurchase(aCurrency, aValue: string);
+  end;
+
+implementation
+
+
+{ tGoogleConversionTracking }
+
+class procedure tGoogleConversionTracking.SetAutomatedReportingEnabled(aEnabled: Boolean);
+begin
+  if aEnabled then
+    TACTAutomatedUsageTracker.OCClass.enableAutomatedUsageReportingWithConversionID(StrToNSStr(cConversionIDStr))
+  else
+    TACTAutomatedUsageTracker.OCClass.disableAutomatedUsageReportingWithConversionID(StrToNSStr(cConversionIDStr));
+end;
+
+class procedure tGoogleConversionTracking.TrackLaunch;
+begin
+   TACTConversionReporter.OCClass.reportWithConversionIDLabelValueIsRepeatable( StrToNSStr(cConversionIDStr),
+                                                                                StrToNSStr(cConversionLabelRun),
+                                                                                StrToNSStr('0.00'), False);
+
+end;
+
+class procedure tGoogleConversionTracking.TrackPurchase(aCurrency, aValue: string);
+begin
+   TACTConversionReporter.OCClass.reportWithConversionIDLabelValueCurrencyCodeIsRepeatable( StrToNSStr(cConversionIDStr),
+                                                                                StrToNSStr(cConversionLabelPurchase),
+                                                                                StrToNSStr(aValue),
+                                                                                StrToNSStr(aCurrency),
+                                                                                False);
+end;
+
+end.

--- a/uGoogleConversionTracking.pas
+++ b/uGoogleConversionTracking.pas
@@ -6,9 +6,9 @@ uses
   iOSapi.GoogleConversionTracking, Macapi.Helpers;
 
 const
-  cConversionIDStr = '1071403861';
-  cConversionLabelRun = 'gAhuCK6Ow2kQ1abx_gM';
-  cConversionLabelPurchase = 'a3SOCKDN42kQ1abx_gM';
+  cConversionIDStr = '0123456789'; //<- input your own Google tracker ID here
+  cConversionLabelRun = 'abcdefgh'; //<- input your own Google conversion ID here
+  cConversionLabelPurchase = 'abcdefgh'; //<- input your own Google conversion ID here
 
 type
   tGoogleConversionTracking = class


### PR DESCRIPTION
- Added a "Fakeloader" function so Delphi automatically includes the
  static library
- Added patches for the FMX.InAppPurchase files (Berlin editions) for
  iOS. To report sales to Google (and Facebook) you need to know the ISO
  Currencycode. This is not currently published by the InAppPurchase
  control. This is the changes needed to publish CurrencyCode.
- Added a simple wrapper unit to make it simpler to call the functions
  in the API
